### PR TITLE
Add translation of bot responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# node/npm specific files
+/node_modules/
+/package-lock.json
+
+# queso queue specific files
+/*.save

--- a/chatbot.js
+++ b/chatbot.js
@@ -42,7 +42,9 @@ const chatbot_helper = function(username, password, channel) {
         // Remove whitespace from chat message
         const command = message.trim();
         const respond = (response_text) => {
-          client.say(channel, response_text);
+          if (response_text !== undefined) { // if i18n errors the response_text might be undefined
+            client.say(channel, response_text);
+          }
         };
         var chatter;
         if (tags.badges == null) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var queue_open = false;
 var selection_iter = 0;
 const level_timer = timer.timer(
   () => {
-    chatbot_helper.say(__('timer.expired', global_lang));
+    chatbot_helper.say(__mf('timer.expired', global_lang));
   },
   settings.level_timeout * 1000 * 60
 );
@@ -44,37 +44,37 @@ const level_list_message = (sender, current, levels) => {
     levels.online.length === 0 &&
     levels.offline.length === 0
   ) {
-    return __('queue.list.empty', {sender, ...global_lang});
+    return __mf('queue.list.empty', {sender, ...global_lang});
   }
 
-  let levels5 = levels.online.slice(0, 5).reduce((acc, x) => acc + __('listSeparator') + x.submitter, '');
+  let levels5 = levels.online.slice(0, 5).reduce((acc, x) => acc + __mf('listSeparator') + x.submitter, '');
   let etc = levels.online.length > 5;
   let online = levels.online.length + (current !== undefined ? 1 : 0);
   let offline = levels.offline.length;
-  return __mf('queue.list.message_mf', {...current, levels: levels5, etc, online, offline, sender, ...global_lang});
+  return __mf('queue.list.message', {...current, levels: levels5, etc, online, offline, sender, ...global_lang});
 };
 
 const next_level_message = (level, sender = undefined, type = undefined) => {
   if (level === undefined) {
-    return __mf('queue.next.empty_mf', {type, sender, ...global_lang});
+    return __mf('queue.next.empty', {type, sender, ...global_lang});
   }
-  return __mf('queue.next.level_mf', {...level, type, sender, ...global_lang});
+  return __mf('queue.next.level', {...level, type, sender, ...global_lang});
 };
 
 const current_level_message = (level, sender = undefined) => {
   if (level === undefined) {
-    return __('queue.current.empty', {sender, ...global_lang});
+    return __mf('queue.current.empty', {sender, ...global_lang});
   }
-  return __('queue.current.level', {...level, sender, ...global_lang});
+  return __mf('queue.current.level', {...level, sender, ...global_lang});
 };
 
 const position_message = async (position, sender) => {
   if (position == -1) {
-    return __('queue.position.unavailable', {sender, ...global_lang});
+    return __mf('queue.position.unavailable', {sender, ...global_lang});
   } else if (position === 0) {
-    return __('queue.position.current', {sender, ...global_lang});
+    return __mf('queue.position.current', {sender, ...global_lang});
   }
-  return __mf('queue.position.position_mf', {position, sender, ...global_lang});
+  return __mf('queue.position.position', {position, sender, ...global_lang});
 };
 
 // What the bot should do when someone sends a message in chat.
@@ -87,18 +87,18 @@ async function HandleMessage(message, sender, respond) {
   twitch.noticeChatter(sender);
   if (message == '!open' && sender.isBroadcaster) {
     queue_open = true;
-    respond(__('queue.open', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('queue.open', {sender: sender.displayName, ...global_lang}));
   } else if (message == '!close' && sender.isBroadcaster) {
     queue_open = false;
-    respond(__('queue.close', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('queue.close', {sender: sender.displayName, ...global_lang}));
   } else if (message.startsWith('!add')) {
     if (queue_open || sender.isBroadcaster) {
       let level_code = get_remainder(message);
       let level = Level(level_code, sender.displayName);
       let result = quesoqueue.add(level);
-      respond(__(`queue.add.${result}`, {...level, sender: sender.displayName, ...global_lang}));
+      respond(__mf(`queue.add.${result}`, {...level, sender: sender.displayName, ...global_lang}));
     } else {
-      respond(__('queue.add.closed', {sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.add.closed', {sender: sender.displayName, ...global_lang}));
     }
   } else if (message.startsWith('!remove') || message.startsWith('!leave')) {
     var result = undefined;
@@ -112,9 +112,9 @@ async function HandleMessage(message, sender, respond) {
       command = "remove";
     }
     if (result === undefined) {
-      respond(__(`queue.${command}.unavailable`, {sender: sender.displayName, ...global_lang}));
+      respond(__mf(`queue.${command}.unavailable`, {sender: sender.displayName, ...global_lang}));
     } else {
-      respond(__(`queue.${command}.current`, {...result, sender: sender.displayName, ...global_lang}));
+      respond(__mf(`queue.${command}.current`, {...result, sender: sender.displayName, ...global_lang}));
     }
   } else if (
     message.startsWith('!replace') ||
@@ -124,7 +124,7 @@ async function HandleMessage(message, sender, respond) {
     let level_code = get_remainder(message);
     let level = Level(level_code, sender.displayName);
     let result = quesoqueue.replace(level.submitter, level.code);
-    respond(__(`queue.replace.${result}`, {...level, sender: sender.displayName, ...global_lang}));
+    respond(__mf(`queue.replace.${result}`, {...level, sender: sender.displayName, ...global_lang}));
   } else if (message == '!level' && sender.isBroadcaster) {
     let next_level = undefined;
     let selection_mode = settings.level_selection[selection_iter++];
@@ -192,9 +192,9 @@ async function HandleMessage(message, sender, respond) {
     level_timer.pause();
     let punt_level = await quesoqueue.punt();
     if (punt_level !== undefined) {
-      respond(__('queue.punt.current', {...punt_level, sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.punt.current', {...punt_level, sender: sender.displayName, ...global_lang}));
     } else {
-      respond(__('queue.punt.unavailable', {sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.punt.unavailable', {sender: sender.displayName, ...global_lang}));
     }
   } else if (message.startsWith('!dip') && sender.isBroadcaster) {
     var username = get_remainder(message);
@@ -202,9 +202,9 @@ async function HandleMessage(message, sender, respond) {
     level_timer.pause();
     var dip_level = quesoqueue.dip(username);
     if (dip_level !== undefined) {
-      respond(__('queue.dip.current', {...dip_level, sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.dip.current', {...dip_level, sender: sender.displayName, ...global_lang}));
     } else {
-      respond(__('queue.dip.unavailable', {username, sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.dip.unavailable', {username, sender: sender.displayName, ...global_lang}));
     }
   } else if (message == '!current') {
     respond(current_level_message(quesoqueue.current(), sender.displayName));
@@ -214,42 +214,42 @@ async function HandleMessage(message, sender, respond) {
       setTimeout(() => can_list = true, settings.message_cooldown * 1000);
       respond(level_list_message(sender.displayName, quesoqueue.current(), await quesoqueue.list()));
     } else {
-      respond(__('queue.list.messageCooldown', {sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.list.messageCooldown', {sender: sender.displayName, ...global_lang}));
     }
   } else if (message == '!position') {
     respond(await position_message(await quesoqueue.position(sender.displayName), sender.displayName));
   } else if (message == '!start' && sender.isBroadcaster) {
     level_timer.resume();
-    respond(__('timer.start', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('timer.start', {sender: sender.displayName, ...global_lang}));
   } else if (message == '!resume' && sender.isBroadcaster) {
     level_timer.resume();
-    respond(__('timer.resume', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('timer.resume', {sender: sender.displayName, ...global_lang}));
   } else if (message == '!pause' && sender.isBroadcaster) {
     level_timer.pause();
-    respond(__('timer.pause', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('timer.pause', {sender: sender.displayName, ...global_lang}));
   } else if (message == '!restart' && sender.isBroadcaster) {
     level_timer.restart();
-    respond(__('timer.restart', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('timer.restart', {sender: sender.displayName, ...global_lang}));
   } else if (message == '!restore' && sender.isBroadcaster) {
     quesoqueue.load();
     respond(level_list_message(quesoqueue.current(), await quesoqueue.list()));
   } else if (message == '!clear' && sender.isBroadcaster) {
     quesoqueue.clear();
-    respond(__('queue.clear', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('queue.clear', {sender: sender.displayName, ...global_lang}));
   } else if (message == '!lurk') {
     twitch.setToLurk(sender.username);
-    respond(__('queue.lurk', {sender: sender.displayName, ...global_lang}));
+    respond(__mf('queue.lurk', {sender: sender.displayName, ...global_lang}));
   } else if (message == '!back') {
     if (twitch.notLurkingAnymore(sender.username)) {
-      respond(__('queue.back', {sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.back', {sender: sender.displayName, ...global_lang}));
     }
   } else if (message == '!order') {
     if (settings.level_selection.length == 0) {
-      respond(__('queue.order.unavailable', {sender: sender.displayName, ...global_lang}));
+      respond(__mf('queue.order.unavailable', {sender: sender.displayName, ...global_lang}));
     } else {
-      let order = settings.level_selection.map(type => __mf('queue.order.type_mf', {type})).reduce((acc, x) => acc + __('listSeparator') + x);
-      let next = __mf('queue.order.type_mf', {type: settings.level_selection[selection_iter % settings.level_selection.length]});
-      respond(__('queue.order.current', {order, next, sender: sender.displayName, ...global_lang}));
+      let order = settings.level_selection.map(type => __mf('queue.order.type', {type})).reduce((acc, x) => acc + __mf('listSeparator') + x);
+      let next = __mf('queue.order.type', {type: settings.level_selection[selection_iter % settings.level_selection.length]});
+      respond(__mf('queue.order.current', {order, next, sender: sender.displayName, ...global_lang}));
     }
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -18,29 +18,29 @@
 			"level": "{type, select, undefined {} other {({type}) }}Next is {code}, submitted by {submitter}"
 		},
 		"current": {
-			"empty": "We're not playing a level right now! D:",
+			"empty": "We''re not playing a level right now! D:",
 			"level": "Currently playing {code}, submitted by {submitter}"
 		},
 		"position": {
 			"position": "{sender}, you are currently {position, selectordinal, one{#st} two{#nd} few{#rd} other{#th}}",
-			"unavailable": "{sender}, looks like you're not in the queue. Try {command_add} AAA-AAA-AAA.",
+			"unavailable": "{sender}, looks like you''re not in the queue. Try {command_add} AAA-AAA-AAA.",
 			"current": "Your level is being played right now!"
 		},
 		"open": "The queue is now open!",
 		"close": "The queue is now closed!",
 		"add": {
 			"full": "Sorry, the level queue is full!",
-			"invalid": "I'm pretty sure '{code}' isn't a valid code. Try again.",
+			"invalid": "I''m pretty sure ''{code}'' isn''t a valid code. Try again.",
 			"current": "Wait for your level to be completed before you submit again.",
 			"added": "{submitter}, {code} has been added to the queue.",
 			"limit": "Sorry, viewers are limited to one submission at a time.",
 			"closed": "Sorry, the queue is closed right now :c"
 		},
 		"replace": {
-			"invalid": "I'm pretty sure '{code}' isn't a valid code.  Try again.",
+			"invalid": "I''m pretty sure ''{code}'' isn''t a valid code.  Try again.",
 			"replaced": "Ok {submitter}, your code in the queue is now {code}.",
 			"replacedCurrent": "Ok {submitter}, your code in the queue is now {code}.",
-			"unavailable": "I didn't find a level for {submitter} in the queue. Use {command_add} to add one."
+			"unavailable": "I didn''t find a level for {submitter} in the queue. Use {command_add} to add one."
 		},
 		"clear": "Queue cleared! A fresh start.",
 		"order": {
@@ -52,19 +52,19 @@
 		"back": "Welcome back {sender}!",
 		"dip": {
 			"unavailable": "No levels in the queue were submitted by {username}",
-			"current": "{submitter}'s level {code} has been pulled up from the queue."
+			"current": "{submitter}''s level {code} has been pulled up from the queue."
 		},
 		"punt": {
-			"unavailable": "The nothing you aren't playing cannot be punted.",
+			"unavailable": "The nothing you aren''t playing cannot be punted.",
 			"current": "Ok, adding the current level back into the queue."
 		},
 		"remove": {
-			"unavailable": "We're playing that level right now!  Don't take this away from us!",
-			"current": "{username}'s level removed from the queue."
+			"unavailable": "We''re playing that level right now!  Don''t take this away from us!",
+			"current": "{username}''s level removed from the queue."
 		},
 		"modRemove": {
-			"unavailable": "You can use {command_remove} <username> to kick out someone else's level;  if you want to skip the current one, use !next.",
-			"current": "Ok, I removed {username}'s level from the queue."
+			"unavailable": "You can use {command_remove} <username> to kick out someone else''s level;  if you want to skip the current one, use !next.",
+			"current": "Ok, I removed {username}''s level from the queue."
 		}
 	}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,7 @@
 {
 	"listSeparator": ", ",
 	"timer": {
-		"expired": "@{{{channel}}} the timer has expired for this level!",
+		"expired": "@{channel} the timer has expired for this level!",
 		"start": "Timer started! Get going!",
 		"pause": "Timer paused",
 		"resume": "Timer unpaused! Get going!",
@@ -11,48 +11,48 @@
 		"list": {
 			"empty": "There are no levels in the queue :c",
 			"messageCooldown": "Just...scroll up a little",
-			"message_mf": "{online} online: {submitter, select, undefined {(no current level)} other {{submitter} (current)}}{levels}{etc, select, true {... etc.} other {}} ({offline} offline)"
+			"message": "{online} online: {submitter, select, undefined {(no current level)} other {{submitter} (current)}}{levels}{etc, select, true {... etc.} other {}} ({offline} offline)"
 		},
 		"next": {
-			"empty_mf": "The queue is empty.  Feed me levels!",
-			"level_mf": "{type, select, undefined {} other {({type}) }}Next is {code}, submitted by {submitter}"
+			"empty": "The queue is empty.  Feed me levels!",
+			"level": "{type, select, undefined {} other {({type}) }}Next is {code}, submitted by {submitter}"
 		},
 		"current": {
 			"empty": "We're not playing a level right now! D:",
-			"level": "Currently playing {{{code}}}, submitted by {{{submitter}}}"
+			"level": "Currently playing {code}, submitted by {submitter}"
 		},
 		"position": {
-			"position_mf": "{sender}, you are currently {position, selectordinal, one{#st} two{#nd} few{#rd} other{#th}}",
-			"unavailable": "{{{sender}}}, looks like you're not in the queue. Try {{{command_add}}} AAA-AAA-AAA.",
+			"position": "{sender}, you are currently {position, selectordinal, one{#st} two{#nd} few{#rd} other{#th}}",
+			"unavailable": "{sender}, looks like you're not in the queue. Try {command_add} AAA-AAA-AAA.",
 			"current": "Your level is being played right now!"
 		},
 		"open": "The queue is now open!",
 		"close": "The queue is now closed!",
 		"add": {
 			"full": "Sorry, the level queue is full!",
-			"invalid": "I'm pretty sure '{{{code}}}' isn't a valid code. Try again.",
+			"invalid": "I'm pretty sure '{code}' isn't a valid code. Try again.",
 			"current": "Wait for your level to be completed before you submit again.",
-			"added": "{{{submitter}}}, {{{code}}} has been added to the queue.",
+			"added": "{submitter}, {code} has been added to the queue.",
 			"limit": "Sorry, viewers are limited to one submission at a time.",
 			"closed": "Sorry, the queue is closed right now :c"
 		},
 		"replace": {
-			"invalid": "I'm pretty sure '{{{code}}}' isn't a valid code.  Try again.",
-			"replaced": "Ok {{{submitter}}}, your code in the queue is now {{{code}}}.",
-			"replacedCurrent": "Ok {{{submitter}}}, your code in the queue is now {{{code}}}.",
-			"unavailable": "I didn't find a level for {{{submitter}}} in the queue. Use {{{command_add}}} to add one."
+			"invalid": "I'm pretty sure '{code}' isn't a valid code.  Try again.",
+			"replaced": "Ok {submitter}, your code in the queue is now {code}.",
+			"replacedCurrent": "Ok {submitter}, your code in the queue is now {code}.",
+			"unavailable": "I didn't find a level for {submitter} in the queue. Use {command_add} to add one."
 		},
 		"clear": "Queue cleared! A fresh start.",
 		"order": {
-			"type_mf": "{type}",
+			"type": "{type}",
 			"unavailable": "No order has been specified.",
-			"current": "Level order: {{{order}}}. Next level will be: {{{next}}}"
+			"current": "Level order: {order}. Next level will be: {next}"
 		},
-		"lurk": "{{{sender}}}, your level will not be played until you use the {{{command_back}}} command.",
-		"back": "Welcome back {{{sender}}}!",
+		"lurk": "{sender}, your level will not be played until you use the {command_back} command.",
+		"back": "Welcome back {sender}!",
 		"dip": {
-			"unavailable": "No levels in the queue were submitted by {{{username}}}",
-			"current": "{{{submitter}}}'s level {{{code}}} has been pulled up from the queue."
+			"unavailable": "No levels in the queue were submitted by {username}",
+			"current": "{submitter}'s level {code} has been pulled up from the queue."
 		},
 		"punt": {
 			"unavailable": "The nothing you aren't playing cannot be punted.",
@@ -60,11 +60,11 @@
 		},
 		"remove": {
 			"unavailable": "We're playing that level right now!  Don't take this away from us!",
-			"current": "{{{username}}}'s level removed from the queue."
+			"current": "{username}'s level removed from the queue."
 		},
 		"modRemove": {
-			"unavailable": "You can use {{{command_remove}}} <username> to kick out someone else's level;  if you want to skip the current one, use !next.",
-			"current": "Ok, I removed {{{username}}}'s level from the queue."
+			"unavailable": "You can use {command_remove} <username> to kick out someone else's level;  if you want to skip the current one, use !next.",
+			"current": "Ok, I removed {username}'s level from the queue."
 		}
 	}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,70 @@
+{
+	"listSeparator": ", ",
+	"timer": {
+		"expired": "@{{{channel}}} the timer has expired for this level!",
+		"start": "Timer started! Get going!",
+		"pause": "Timer paused",
+		"resume": "Timer unpaused! Get going!",
+		"restart": "Starting the clock over! CP Hype!"
+	},
+	"queue": {
+		"list": {
+			"empty": "There are no levels in the queue :c",
+			"messageCooldown": "Just...scroll up a little",
+			"message_mf": "{online} online: {submitter, select, undefined {(no current level)} other {{submitter} (current)}}{levels}{etc, select, true {... etc.} other {}} ({offline} offline)"
+		},
+		"next": {
+			"empty_mf": "The queue is empty.  Feed me levels!",
+			"level_mf": "{type, select, undefined {} other {({type}) }}Next is {code}, submitted by {submitter}"
+		},
+		"current": {
+			"empty": "We're not playing a level right now! D:",
+			"level": "Currently playing {{{code}}}, submitted by {{{submitter}}}"
+		},
+		"position": {
+			"position_mf": "{sender}, you are currently {position, selectordinal, one{#st} two{#nd} few{#rd} other{#th}}",
+			"unavailable": "{{{sender}}}, looks like you're not in the queue. Try {{{command_add}}} AAA-AAA-AAA.",
+			"current": "Your level is being played right now!"
+		},
+		"open": "The queue is now open!",
+		"close": "The queue is now closed!",
+		"add": {
+			"full": "Sorry, the level queue is full!",
+			"invalid": "I'm pretty sure '{{{code}}}' isn't a valid code. Try again.",
+			"current": "Wait for your level to be completed before you submit again.",
+			"added": "{{{submitter}}}, {{{code}}} has been added to the queue.",
+			"limit": "Sorry, viewers are limited to one submission at a time.",
+			"closed": "Sorry, the queue is closed right now :c"
+		},
+		"replace": {
+			"invalid": "I'm pretty sure '{{{code}}}' isn't a valid code.  Try again.",
+			"replaced": "Ok {{{submitter}}}, your code in the queue is now {{{code}}}.",
+			"replacedCurrent": "Ok {{{submitter}}}, your code in the queue is now {{{code}}}.",
+			"unavailable": "I didn't find a level for {{{submitter}}} in the queue. Use {{{command_add}}} to add one."
+		},
+		"clear": "Queue cleared! A fresh start.",
+		"order": {
+			"type_mf": "{type}",
+			"unavailable": "No order has been specified.",
+			"current": "Level order: {{{order}}}. Next level will be: {{{next}}}"
+		},
+		"lurk": "{{{sender}}}, your level will not be played until you use the {{{command_back}}} command.",
+		"back": "Welcome back {{{sender}}}!",
+		"dip": {
+			"unavailable": "No levels in the queue were submitted by {{{username}}}",
+			"current": "{{{submitter}}}'s level {{{code}}} has been pulled up from the queue."
+		},
+		"punt": {
+			"unavailable": "The nothing you aren't playing cannot be punted.",
+			"current": "Ok, adding the current level back into the queue."
+		},
+		"remove": {
+			"unavailable": "We're playing that level right now!  Don't take this away from us!",
+			"current": "{{{username}}}'s level removed from the queue."
+		},
+		"modRemove": {
+			"unavailable": "You can use {{{command_remove}}} <username> to kick out someone else's level;  if you want to skip the current one, use !next.",
+			"current": "Ok, I removed {{{username}}}'s level from the queue."
+		}
+	}
+}

--- a/settings.js
+++ b/settings.js
@@ -9,4 +9,6 @@ module.exports = {
   // example: ['next', 'subnext', 'random']
   level_selection: [],
   message_cooldown: 5,
+  locale: 'en', // the selected language
+  locales: ['en'], // all installed language files (within the locales folder)
 };


### PR DESCRIPTION
I have created a file containing all bot responses (`locales/en.json`).
The main reason i created it, is to be able to easily change bot response messages, but the changes would also allow for translation into other languages.
I used [i18n](https://github.com/mashpie/i18n-node) to do so.
Some messages have the suffix `_mf` in the key. Those messages are translated using [i18n.__mf()](https://github.com/mashpie/i18n-node#i18n__mf), which allows the messages to be formatted with [messageformat](https://messageformat.github.io/messageformat/page-guide) (which enables ordinal translations and switch statements).
I wonder if it would be less confusing (and more consistent) to just use `i18n.__mf()` for all messages.
There are 2 more settings: `locales` and `locale`.
I also added a `.gitignore` file.