### PR TITLE
Hotfix offline localized display names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# node/npm specific files
+/node_modules/
+/package-lock.json
+
+# queso queue specific files
+/*.save

--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ const get_remainder = x => {
   return x.substr(index + 1);
 };
 
-const Level = (level_code, submitter) => {
-  return { code: level_code, submitter: submitter };
+const Level = (level_code, submitter, username) => {
+  return { code: level_code, submitter: submitter, username: username };
 };
 
 var can_list = true;
@@ -105,7 +105,7 @@ async function HandleMessage(message, sender, respond) {
   } else if (message.startsWith('!add')) {
     if (queue_open || sender.isBroadcaster) {
       let level_code = get_remainder(message);
-      respond(quesoqueue.add(Level(level_code, sender.displayName)));
+      respond(quesoqueue.add(Level(level_code, sender.displayName, sender.username)));
     } else {
       respond('Sorry, the queue is closed right now :c');
     }

--- a/queue.js
+++ b/queue.js
@@ -267,7 +267,7 @@ const queue = {
       if (levels.some(username_missing)) {
         console.warn(`Usernames are not set in the file ${cache_filename}!`);
         console.warn('Assuming that usernames are lowercase Display Names which does work with Localized Display Names.');
-        console.warn('To be save clear the queue with !clear.');
+        console.warn('To be safe, clear the queue with !clear.');
         levels.forEach(level => {
           if (username_missing(level)) {
             level.username = level.submitter.toLowerCase();

--- a/queue.js
+++ b/queue.js
@@ -215,8 +215,8 @@ const queue = {
     var online = new Array();
     var offline = new Array();
     await twitch.getOnlineUsers(settings.channel).then(online_users => {
-      online = levels.filter(x => online_users.has(x.submitter.toLowerCase()));
-      offline = levels.filter(x => !online_users.has(x.submitter.toLowerCase()));
+      online = levels.filter(x => online_users.has(x.username));
+      offline = levels.filter(x => !online_users.has(x.username));
     });
     return {
       online: online,
@@ -228,8 +228,8 @@ const queue = {
     var online = new Array();
     var offline = new Array();
     await twitch.getOnlineSubscribers(settings.channel).then(online_users => {
-      online = levels.filter(x => online_users.has(x.submitter.toLowerCase()));
-      offline = levels.filter(x => !online_users.has(x.submitter.toLowerCase()));
+      online = levels.filter(x => online_users.has(x.username));
+      offline = levels.filter(x => !online_users.has(x.username));
     });
     return {
       online: online,
@@ -241,8 +241,8 @@ const queue = {
     var online = new Array();
     var offline = new Array();
     await twitch.getOnlineMods(settings.channel).then(online_users => {
-      online = levels.filter(x => online_users.has(x.submitter.toLowerCase()));
-      offline = levels.filter(x => !online_users.has(x.submitter.toLowerCase()));
+      online = levels.filter(x => online_users.has(x.username));
+      offline = levels.filter(x => !online_users.has(x.username));
     });
     return {
       online: online,
@@ -263,6 +263,17 @@ const queue = {
     if (fs.existsSync(cache_filename)) {
       var raw_data = fs.readFileSync(cache_filename);
       levels = JSON.parse(raw_data);
+      const username_missing = level => !level.hasOwnProperty('username');
+      if (levels.some(username_missing)) {
+        console.warn(`Usernames are not set in the file ${cache_filename}!`);
+        console.warn('Assuming that usernames are lowercase Display Names which does work with Localized Display Names.');
+        console.warn('To be save clear the queue with !clear.');
+        levels.forEach(level => {
+          if (username_missing(level)) {
+            level.username = level.submitter.toLowerCase();
+          }
+        });
+      }
       current_level = undefined;
     }
   },


### PR DESCRIPTION
Viewers who submit levels to the queso queue which have [Localized Display Names](https://blog.twitch.tv/en/2016/08/22/localized-display-names-e00ee8d3250a/) are always listed as offline.

The queue only keeps track of the display names, but the offline check only uses the usernames and those are then compared with the lowercase version of the display names, which does not work for Localized Display Names.
I propose storing the username together with the display name in the queue entries and using those usernames to check offline status.
All other commands are still using the display name like they did before (e.g. !dip).