### PR TITLE
Add !dismiss command removing the current level

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ async function HandleMessage(message, sender, respond) {
     level_timer.restart();
     level_timer.pause();
     respond(await quesoqueue.punt());
-  } else if (message == '!dismiss' || message == '!skip' || message.startsWith('!complete')) {
+  } else if ((message == '!dismiss' || message == '!skip' || message.startsWith('!complete')) && sender.isBroadcaster) {
     level_timer.restart();
     level_timer.pause();
     respond(await quesoqueue.dismiss());

--- a/index.js
+++ b/index.js
@@ -188,6 +188,10 @@ async function HandleMessage(message, sender, respond) {
     level_timer.restart();
     level_timer.pause();
     respond(await quesoqueue.punt());
+  } else if (message == '!dismiss' || message == '!skip' || message.startsWith('!complete')) {
+    level_timer.restart();
+    level_timer.pause();
+    respond(await quesoqueue.dismiss());
   } else if (message.startsWith('!dip') && sender.isBroadcaster) {
     var username = get_remainder(message);
     level_timer.restart();

--- a/queue.js
+++ b/queue.js
@@ -97,6 +97,16 @@ const queue = {
     return 'Ok, adding the current level back into the queue.';
   },
 
+  dismiss: async () => {
+    if (current_level === undefined) {
+      return "No current level.";
+    }
+    let response = 'Dismissed ' + current_level.code + ', submitted by ' + current_level.submitter;
+    current_level = undefined;
+    queue.save();
+    return response;
+  },
+
   next: async () => {
     var list = await queue.list();
     var both = list.online.concat(list.offline);


### PR DESCRIPTION
Add a `!dismiss` command which removes the current level from the queue.
Alternative commands are `!skip`, `!complete`, and `!completed`.
All these commands just remove the level from the queue and it can be submitted again.

This command is needed together with fix #6 to ensure that the person who's level got played last can still submit a new level before the first level of the next stream is drawn from the queue.