### PR TITLE
Better username argument handling for commands

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -35,13 +35,17 @@ const queue = {
     }
   },
 
-  modRemove: (username) => {
-    if (username == '') {
+  modRemove: (usernameArgument) => {
+    if (usernameArgument == '') {
       return "You can use !remove <username> to kick out someone else's level;  if you want to skip the current one, use !next.";
     }
 
-    levels = levels.filter(x => x.submitter != username);
-    return "Ok, I removed " + username + "'s level from the queue.";
+    var match = queue.matchUsername(usernameArgument);
+    if (!levels.some(match)) {
+      return "No levels from " + usernameArgument + " in the queue.";
+    }
+    levels = levels.filter(level => !match(level));
+    return "Ok, I removed " + usernameArgument + "'s level from the queue.";
   },
 
   remove: (username) => {
@@ -139,8 +143,8 @@ const queue = {
     return current_level;
   },
 
-  dip: (username) => {
-    var index = levels.findIndex(x => x.submitter == username);
+  dip: (usernameArgument) => {
+    var index = levels.findIndex(queue.matchUsername(usernameArgument));
     if (index != -1) {
       current_level = levels[index];
       levels.splice(index, 1);
@@ -247,6 +251,14 @@ const queue = {
     return {
       online: online,
       offline: offline
+    };
+  },
+
+  matchUsername: (usernameArgument) => {
+    usernameArgument = usernameArgument.trim().replace(/^@/, '');
+    return level => {
+      // display name (submitter) or user name (username) matches
+      return level.submitter == usernameArgument || level.username == usernameArgument;
     };
   },
 


### PR DESCRIPTION
When using `!remove <username>` (modRemove) and `!dip <username>` (or sometimes `!select <username>` in modified versions of the queue) the username argument can now also be the username and not just the display name and also it ignores a leading `@`.